### PR TITLE
Fix runs-on

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   linters:
     name: 'Terraform Linters'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
@@ -69,7 +69,7 @@ jobs:
           download_external_modules: false
   semver:
     name: 'Set code version tag'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     needs:


### PR DESCRIPTION
Fix:
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```